### PR TITLE
Update Required to work with the Facebook SDK version 4.11

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
 
         <config-file target="*-Info.plist" parent="LSApplicationQueriesSchemes">
             <array>
-                <string>fbauth</string>
+                <string>fbauth2</string>
             </array>
         </config-file>
 


### PR DESCRIPTION
Update Required to work with the Facebook SDK version 4.11
